### PR TITLE
Add OptionalCoordinateFrame support

### DIFF
--- a/src/datatypes/fromId.lua
+++ b/src/datatypes/fromId.lua
@@ -29,6 +29,7 @@ local types = {
     [0x1b] = require("datatypes.codecs.int64"),
     [0x1c] = require("datatypes.codecs.sharedstring"),
     [0x1d] = require("datatypes.codecs.bytecode"),
+    [0x1e] = require("datatypes.codecs.cframe")
 }
 
 setmetatable(types, {

--- a/src/datatypes/fromString.lua
+++ b/src/datatypes/fromString.lua
@@ -29,6 +29,7 @@ local types = {
     int64 = require("datatypes.codecs.int64"),
     sharedstring = require("datatypes.codecs.sharedstring"),
     bytecode = require("datatypes.codecs.bytecode"),
+    optionalcoordinateframe = require("datatypes.codecs.cframe")
 }
 
 setmetatable(types, {


### PR DESCRIPTION
Adds [OptionalCoordinateFrame ](https://github.com/rojo-rbx/rbx-dom/blob/master/docs/binary.md#optionalcoordinateframe) read support based on CFrame, otherwise reading models will fail.